### PR TITLE
sort the metadata keys so the column order does not depend on the engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## [Unreleased]
+## [3.0.1] -2026-09-03
 
-### Fixed
-* The CSV column order no longer depends on the workflow engine. `metadata` is a WDL `Map`,
-  which has no defined ordering, so `write_json` emitted its keys in whatever order the engine
-  iterated the map; that order reached the output columns unchanged, because the caller builds
-  its DataFrame with `from_records` and takes the keys as it first meets them. A Cromwell
-  upgrade was enough to reorder every column. `writeMetadata` now sorts the keys, so the
-  columns are alphabetical and stable. Existing baselines must be regenerated once.
+### Changed
+* Sort metadata output keys. different ordering created issue in different environment, see ticket: GP-5853 
 
 ## [3.0.0] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+* The CSV column order no longer depends on the workflow engine. `metadata` is a WDL `Map`,
+  which has no defined ordering, so `write_json` emitted its keys in whatever order the engine
+  iterated the map; that order reached the output columns unchanged, because the caller builds
+  its DataFrame with `from_records` and takes the keys as it first meets them. A Cromwell
+  upgrade was enough to reorder every column. `writeMetadata` now sorts the keys, so the
+  columns are alphabetical and stable. Existing baselines must be regenerated once.
+
 ## [3.0.0] - 2026-05-28
 
 ### Changed

--- a/crosscheckFingerprintCaller.wdl
+++ b/crosscheckFingerprintCaller.wdl
@@ -155,7 +155,8 @@ task writeMetadata {
 
     command <<<
         set -euo pipefail
-        jq '.dummy' ~{out_metadata} > metadata.json
+        # -S sorts the keys. different ordering created issue in different environment, see ticket: GP-5853 
+        jq -S '.dummy' ~{out_metadata} > metadata.json
     >>>
 
     output {

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -10,7 +10,7 @@
 			{
 				"metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
 				"metrics_compare": "@CHECKOUT@/tests/compare.sh",
-				"output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintCaller/expected_output_v2/single_input.calculate.output",
+				"output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintCaller/3.0.1/output_metrics/single_input.output",
 				"type": "script"
 			}
 		],
@@ -153,7 +153,7 @@
 			{
 				"metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
 				"metrics_compare": "@CHECKOUT@/tests/compare.sh",
-				"output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintCaller/expected_output_v2/no_swap.calculate.output",
+				"output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintCaller/3.0.1/output_metrics/no_swap.output",
 				"type": "script"
 			}
 		],
@@ -350,7 +350,7 @@
 			{
 				"metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
 				"metrics_compare": "@CHECKOUT@/tests/compare.sh",
-				"output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintCaller/expected_output_v2/swap.calculate.output",
+				"output_metrics": "/.mounts/labs/gsi/testdata/crosscheckFingerprintCaller/3.0.1/output_metrics/swap.output",
 				"type": "script"
 			}
 		],


### PR DESCRIPTION
I am working on ticket: https://jira.oicr.on.ca/browse/GP-5853
this error is caused by the order difference of outputed metadata, and can be addressed by sort. 
also the regression test metrics need changed: see https://gsici.hpc.oicr.on.ca/job/crosscheckFingerprintCaller_vidarr/job/gavin_patch/1/execution/node/14/log/
I don't have permission to change the metrics